### PR TITLE
Logout and Nav Header on Dashboard

### DIFF
--- a/api/ver1/urls.py
+++ b/api/ver1/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 from rest_framework.authtoken.views import obtain_auth_token
-from ver1.views.authViews import RegisterView
+from ver1.views.authViews import LogoutView, RegisterView
 
 urlpatterns = [
-    path('register/', RegisterView.as_view()),
+    path('register/', RegisterView.as_view(), name='register'),
     path('login/', obtain_auth_token, name='login'),
+    path('logout/',  LogoutView.as_view(), name='logout'),
 ]

--- a/api/ver1/views/authViews.py
+++ b/api/ver1/views/authViews.py
@@ -10,3 +10,10 @@ class RegisterView(APIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)
+    
+class LogoutView(APIView):
+    def post(self, request):
+        request.user.auth_token.delete()
+        return Response({
+            'message': "User logged out"
+        })

--- a/client/src/components/Navbar/NavbarDropdown.tsx
+++ b/client/src/components/Navbar/NavbarDropdown.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useRef, type ReactElement } from 'react';
+import Link from 'next/link';
+import ChevronIcon from '@/src/icons/ChevronIcon';
+import { useAppDispatch } from '@/src/redux/hooks';
+import { useLogoutUserMutation } from '@/src/redux/services/authAPI';
+import { useRouter } from 'next/router';
+
+export interface Option {
+  text: string;
+  url: string;
+}
+
+export interface NavBarDropdownProps {
+  options: Option[];
+  classNames?: string;
+  children?: ReactElement;
+  showArrowIcon?: boolean;
+}
+
+const NavBarDropdown: React.FC<NavBarDropdownProps> = ({
+  options,
+  classNames,
+  showArrowIcon = true,
+  children,
+}: NavBarDropdownProps) => {
+  const [selectedOption, setSelectedOption] = useState<string | undefined>(undefined);
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const dispatch = useAppDispatch();
+  const [logoutUser] = useLogoutUserMutation();
+  const { push } = useRouter();
+
+  const handleOptionSelectEvent = (option: string): void => {
+    setSelectedOption(option);
+    setIsOpen(false);
+  };
+
+  const handleLgout = (): void => {
+    dispatch(logoutUser);
+    localStorage.setItem('token', '');
+    push('/auth/sign-in');
+  };
+
+  return (
+    <div className="relative inline-block text-left z-10 h-10" ref={dropdownRef}>
+      <button
+        type="button"
+        className={`inline-flex justify-between w-full rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none ${
+          classNames !== undefined ? classNames : ''
+        }`}
+        id="options-menu"
+        aria-haspopup="true"
+        aria-expanded="true"
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        <span>{children}</span>
+        {showArrowIcon && (
+          <div className="-mr-1 ml-2 h-5 w-5" aria-hidden="true">
+            <ChevronIcon height={20} width={20} />
+          </div>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          className="origin-top-right absolute mt-2 -right-4 w-56 rounded-md shadow-lg bg-white ring-black ring-opacity-5 focus:outline-none"
+          role="menu"
+          aria-orientation="vertical"
+          aria-labelledby="options-menu"
+        >
+          <div className="py-1" role="none">
+            {options.map((option) => (
+              <Link
+                key={option.url}
+                href={`${option.url}`}
+                className={`${
+                  selectedOption === option.url ? 'bg-gray-100 text-gray-900' : 'text-gray-700'
+                } block px-4 py-2 text-sm w-full text-left hover:bg-gray-100`}
+                role="menuitem"
+                onClick={() => {
+                  handleOptionSelectEvent(option.url);
+                }}
+              >
+                {option.text}
+              </Link>
+            ))}
+            <button
+              className="block px-4 py-2 text-sm w-full text-left hover:bg-gray-100 border-t border-gray-200"
+              onClick={handleLgout}
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NavBarDropdown;

--- a/client/src/components/Navbar/index.tsx
+++ b/client/src/components/Navbar/index.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { FC } from 'react';
+import NavBarDropdown from './NavbarDropdown';
+import { isAuthenticated } from '@/src/utils';
+
+const Navbar: FC = () => {
+  const { asPath } = useRouter();
+
+  const navItems = [
+    { url: '/dashboard', text: 'Dashboard' },
+    { url: '/sentimentify', text: 'Sentimentify' },
+    { url: '/sentimentify/history', text: 'History' },
+  ];
+
+  const dropdownItems = [{ text: 'Profile', url: '/auth/progile' }];
+  if (!isAuthenticated()) {
+    return null;
+  }
+
+  return (
+    <header className="sticky top-0 z-10 px-[64px] flex shadow-sm bg-white text-textGray items-center text-[14px]">
+      <nav className="hidden md:flex grow justify-center">
+        <ul className="flex space-x-[32px]">
+          {navItems.map((navItem, index) => (
+            <li key={index} className="pointer-events-none">
+              <Link
+                className={`flex items-center px-[8px] py-[21px] border-b pointer-events-auto ${
+                  new RegExp('^' + navItem.url).test(asPath)
+                    ? ' border-amber-800'
+                    : 'border-transparent'
+                }`}
+                href={navItem.url}
+              >
+                {navItem.text}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="flex items-center space-x-2">
+        <NavBarDropdown options={dropdownItems}>
+          <p>Option</p>
+        </NavBarDropdown>
+      </div>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/client/src/icons/ChevronIcon.tsx
+++ b/client/src/icons/ChevronIcon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface ChevronProps {
+  height: number;
+  width: number;
+  className?: string;
+  color?: string;
+}
+
+const ChevronIcon: React.FC<ChevronProps> = ({ height, width, className, color }: ChevronProps) => {
+  return (
+    <svg
+      height={height}
+      width={width}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke={color}
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+    </svg>
+  );
+};
+
+ChevronIcon.defaultProps = {
+  className: '',
+  color: 'currentColor',
+};
+
+export default ChevronIcon;

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -5,11 +5,13 @@ import 'react-toastify/dist/ReactToastify.css';
 import { ToastContainer } from 'react-toastify';
 import { Provider } from 'react-redux';
 import { store } from '@/src/redux/store';
+import Navbar from '../components/Navbar';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <Provider store={store}>
       <Fragment>
+        <Navbar />
         <Component {...pageProps} />
         <ToastContainer />
       </Fragment>

--- a/client/src/pages/auth/sign-in.tsx
+++ b/client/src/pages/auth/sign-in.tsx
@@ -28,7 +28,7 @@ const SignIn = (): ReactNode => {
         throw new Error(errorMessage);
       } else {
         localStorage.setItem('token', res.data.token);
-        await push('/sentimentify');
+        await push('/dashboard');
         alertSuccess('User Registered Successfully');
       }
     } catch (error: any) {

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -1,0 +1,13 @@
+import Container from '@/src/components/Container';
+import Headings from '@/src/components/Headings';
+import { ReactNode } from 'react';
+
+const Dashboard = (): ReactNode => {
+  return (
+    <Container>
+      <Headings option={'h1'} text={'Dashboard'} />
+    </Container>
+  );
+};
+
+export default Dashboard;

--- a/client/src/redux/services/authAPI.ts
+++ b/client/src/redux/services/authAPI.ts
@@ -1,3 +1,4 @@
+import { getUserToken } from '@/src/utils';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 export const authAPI = createApi({
@@ -25,10 +26,24 @@ export const authAPI = createApi({
       invalidatesTags: ['auth'],
     }),
 
+    logoutUser: builder.mutation({
+      query: () => {
+        return {
+          url: 'logout/',
+          method: 'POST',
+          headers: {
+            Authorization: `Token ${getUserToken()}`,
+          },
+        };
+      },
+      invalidatesTags: ['auth'],
+    }),
+
   }),
 });
 
 export const {
   useRegisterUserMutation,
   useLoginUserMutation,
+  useLogoutUserMutation,
 } = authAPI;

--- a/client/src/utils/auth.ts
+++ b/client/src/utils/auth.ts
@@ -1,3 +1,7 @@
+export const isAuthenticated = (): boolean => {
+  return typeof localStorage !== 'undefined' && localStorage.getItem('token') !== '' && localStorage.getItem('token') !== null;
+}
+
 export const getUserToken = (): string | null => {
     if (
       typeof localStorage !== 'undefined' &&


### PR DESCRIPTION
## Task ID
ID: senti-6

## Definition of Done
Logout & navbar created

## Steps to reproduce
- click the option in navbar
- select logout
- it should destroy the token and remove the token in localstorage
- should redirect to sign-in page

## Affected Files
- api/ver1/urls.py
- api/ver1/views/authViews.py
- client/src/pages/_app.tsx
- client/src/pages/auth/sign-in.tsx
- client/src/redux/services/authAPI.ts
- client/src/utils/auth.ts

## Notes
page acces is not configured yet, regardless of authenticated or not, pages is accesible through manual typing in URL